### PR TITLE
Fix backlight function names

### DIFF
--- a/main/lvgl_port.h
+++ b/main/lvgl_port.h
@@ -139,7 +139,7 @@ esp_err_t lvgl_port_init(esp_lcd_panel_handle_t lcd_handle, esp_lcd_touch_handle
 /**
  * @brief Take LVGL mutex
  *
- * @param[in] timeout_ms: Timeout in [ms]. 0 will block indefinitely.
+ * @param[in] timeout_ms: Timeout in [ms]. A negative value blocks indefinitely.
  *
  * @return
  *      - true:  Mutex was taken

--- a/main/main.c
+++ b/main/main.c
@@ -14,9 +14,9 @@ void app_main()
 {
     
     waveshare_esp32_s3_rgb_lcd_init(); // Initialize the Waveshare ESP32-S3 RGB LCD 
-    // wavesahre_rgb_lcd_bl_on();  //Turn on the screen backlight 
+    // waveshare_rgb_lcd_bl_on();  // Turn on the screen backlight
     //Initialize touchscreen
-    // wavesahre_rgb_lcd_bl_off(); //Turn off the screen backlight 
+    // waveshare_rgb_lcd_bl_off(); // Turn off the screen backlight
     
     
     ESP_LOGI(TAG, "Display LVGL demos");

--- a/main/waveshare_rgb_lcd_port.c
+++ b/main/waveshare_rgb_lcd_port.c
@@ -190,7 +190,7 @@ esp_err_t waveshare_esp32_s3_rgb_lcd_init()
 }
 
 /******************************* Turn on the screen backlight **************************************/
-esp_err_t wavesahre_rgb_lcd_bl_on()
+esp_err_t waveshare_rgb_lcd_bl_on()
 {
     // Configure CH422G to output mode
     uint8_t write_buf = 0x01;
@@ -203,7 +203,7 @@ esp_err_t wavesahre_rgb_lcd_bl_on()
 }
 
 /******************************* Turn off the screen backlight **************************************/
-esp_err_t wavesahre_rgb_lcd_bl_off()
+esp_err_t waveshare_rgb_lcd_bl_off()
 {
     // Configure CH422G to output mode
     uint8_t write_buf = 0x01;

--- a/main/waveshare_rgb_lcd_port.h
+++ b/main/waveshare_rgb_lcd_port.h
@@ -77,8 +77,8 @@ void example_lvgl_unlock(void);
 
 esp_err_t waveshare_esp32_s3_rgb_lcd_init();
 
-esp_err_t wavesahre_rgb_lcd_bl_on();
-esp_err_t wavesahre_rgb_lcd_bl_off();
+esp_err_t waveshare_rgb_lcd_bl_on();
+esp_err_t waveshare_rgb_lcd_bl_off();
 
 void example_lvgl_demo_ui();
 


### PR DESCRIPTION
## Summary
- correct `waveshare_rgb_lcd_bl_on/off` function names
- fix LVGL lock documentation comment
- clean up header formatting

## Testing
- `cmake --version`
- `cmake -S . -B buildtest` *(fails: include could not find requested file `/tools/cmake/project.cmake`)*

------
https://chatgpt.com/codex/tasks/task_e_68406f19c3588331a24f8ed085553e9d