### PR TITLE
Add basic 20 button UI skeleton

### DIFF
--- a/main/buttons_screen.c
+++ b/main/buttons_screen.c
@@ -1,0 +1,20 @@
+#include "buttons_screen.h"
+
+static lv_obj_t *buttons[20];
+
+void buttons_screen_init(void)
+{
+    lv_obj_t *scr = lv_scr_act();
+
+    lv_obj_t *cont = lv_obj_create(scr);
+    lv_obj_set_size(cont, lv_pct(100), lv_pct(100));
+    lv_obj_center(cont);
+    lv_obj_set_flex_flow(cont, LV_FLEX_FLOW_ROW_WRAP);
+    lv_obj_set_flex_align(cont, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
+
+    for (int i = 0; i < 20; i++) {
+        buttons[i] = lv_btn_create(cont);
+        lv_obj_set_size(buttons[i], 80, 40);
+        lv_obj_clear_flag(buttons[i], LV_OBJ_FLAG_SCROLLABLE);
+    }
+}

--- a/main/buttons_screen.h
+++ b/main/buttons_screen.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "lvgl.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void buttons_screen_init(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/main/main.c
+++ b/main/main.c
@@ -5,7 +5,7 @@
  */
 
 #include "waveshare_rgb_lcd_port.h"
-#include "ui.h"
+#include "buttons_screen.h"
 
 
 
@@ -20,11 +20,8 @@ void app_main()
     
     
     ESP_LOGI(TAG, "Display LVGL demos");
-    // Lock the mutex due to the LVGL APIs are not thread-safe
     if (lvgl_port_lock(-1)) {
-    //UI initiazation
-        ui_init();
-
+        buttons_screen_init();
         lvgl_port_unlock();
     }
 }


### PR DESCRIPTION
## Summary
- create `buttons_screen` component to show a grid of 20 buttons
- display the new screen at boot instead of the demo UI

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68408f2c57848331a863a3adf2ded916